### PR TITLE
Add Play Date iOS in-app copy slide

### DIFF
--- a/_posts/0000-01-02-play-date-copy.md
+++ b/_posts/0000-01-02-play-date-copy.md
@@ -1,0 +1,34 @@
+---
+layout: slide
+title: "Play Date iOS In-App Copy Set"
+---
+
+### Brand voice
+- Adult, intentional, fandom-aware
+- Calm, respectful, safety-first
+- No sexualized or gimmicky language
+
+### Onboarding + age gate
+- **Welcome:** "Play Date is a dating app for verified adults who love anime, cosplay, and fandom culture."
+- **21+ gate:** "Play Date is exclusively for adults 21 and over. Identity verification is required to connect with others."
+
+### Account creation
+- **Create account:** "Sign in securely to start building your profile. You’ll verify your identity before matching."
+- **Phone step:** "We use phone verification to help prevent spam and fake accounts."
+
+### Verification flow
+- **CTA:** "Verify to Start Matching"
+- **Promise:** "Government ID, selfie + liveness, takes 1–2 minutes"
+- **Privacy:** "We don’t store ID images"
+- **Outcomes:** Success unlocks matching; failure offers retry + support
+
+### Discover, messaging, and safety
+- Pre-verification state blocks discover/match/message
+- Discover helper: like a photo or prompt to start a conversation
+- Report categories: harassment, inappropriate content, fake account, other
+- Settings essentials: verified status, blocked users, privacy controls, delete account
+
+### Premium copy
+- "Upgrade to Play Date Plus"
+- See who liked you, extra daily likes, advanced filters
+- Verification stays free for everyone


### PR DESCRIPTION
### Motivation
- Provide ship-ready in-app copy for the Play Date iOS MVP inside the existing slideshow so designers and developers have vetted, brand-aligned onboarding, verification, discover, safety, and premium text to use in the app.

### Description
- Add the slide Markdown file `/_posts/0000-01-02-play-date-copy.md` containing structured, App Store–friendly in-app copy for brand voice, onboarding/21+ gate, account creation, verification flow, discover/messaging/safety, and premium positioning.

### Testing
- Ran `script/cibuild` and attempted `bundle install` to validate the Jekyll build, but `script/cibuild` failed due to the missing `jekyll` executable and `bundle install` failed with external gem fetch `403 Forbidden`, so the automated site build could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699529e21d1c832a86b07bc516466423)